### PR TITLE
Added optional userName and passWord to SimpleGdb

### DIFF
--- a/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdb.java
+++ b/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdb.java
@@ -52,20 +52,29 @@ import org.bridgedb.IDMapperException;
  */
 public abstract class SimpleGdb extends IDMapperRdb
 {
-	private final String connectionString;
-	/**
+    private final String connectionString;
+    protected final String dbName;
+    private final String userName;
+    private final String passWord;
+    private boolean singleConnection = true;
+    private boolean neverCloseConnection = true;
+		
+    /**
 	 * Create IDMapper based on an existing SQL connection.
+     * @param dbName Name of the Database
 	 * @param con Existing SQL Connection.
+     * @param userName Userr name for the datapass
+     * @param passWord Password for this user on this database.
+
 	 */
-	SimpleGdb(String dbName, String connectionString)
+	SimpleGdb(String dbName, String connectionString, String userName, String passWord)
 	{
 		this.connectionString = connectionString;
 		this.dbName = dbName;
+		this.userName = userName;
+		this.passWord = passWord;
 	}
 
-	private boolean singleConnection = true;
-	private boolean neverCloseConnection = true;
-	
 	/**
 	 * helper class that handles the life cycle of a connection, query and resultset.
 	 * <p>
@@ -179,7 +188,13 @@ public abstract class SimpleGdb extends IDMapperRdb
 		// if singleConnection is false, each call to getConneciton() will lead to a new connection object being created.
 		if (!singleConnection || con == null)
 		{
-			con = DriverManager.getConnection(connectionString); 
+            if (userName == null){
+                con = DriverManager.getConnection(connectionString);
+            } else if (passWord == null){
+                con = DriverManager.getConnection(connectionString, userName, "");
+            } else {
+                con = DriverManager.getConnection(connectionString, userName, passWord);
+            }
 			con.setReadOnly(true);
 		}
 		return con;
@@ -197,8 +212,6 @@ public abstract class SimpleGdb extends IDMapperRdb
 		return true;
 	}
 
-	protected final String dbName;
-	
 	/** {@inheritDoc} */
 	@Override final public String getDbName() { return dbName; }
 	

--- a/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbFactory.java
+++ b/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbFactory.java
@@ -39,11 +39,31 @@ public final class SimpleGdbFactory
 	 * Opens a connection to the Gene Database located in the given file.
 	 * <p>
 	 * Use this instead of constructor to create an instance of SimpleGdb that matches the schema version.
-	 * @param connectionString a JDBC Connection string 
+     * @param dbName Name of the Database
+	 * @param connectionString a JDBC Connection string. 
+     *    This assumes that no username or password is required.
 	 * @return a new Gdb
 	 * @throws IDMapperException on failure
 	*/
 	public static SimpleGdb createInstance(String dbName, String connectionString) throws IDMapperException
+	{
+        return createInstance(dbName, connectionString, null, null);
+    }
+    
+    /*
+	 * Opens a connection to the Gene Database located in the given file.
+	 * <p>
+	 * Use this instead of constructor to create an instance of SimpleGdb that matches the schema version.
+     * @param dbName Name of the Database
+     * @param connectionString a JDBC Connection string 
+     * @param userName Userr name for the datapass
+     * @param passWord Password for this user on this database.
+	 * @return a new Gdb
+	 * @throws IDMapperException on failure
+     * @throws IDMapperException 
+     */
+	public static SimpleGdb createInstance(String dbName, String connectionString, String userName, String passWord) 
+            throws IDMapperException
 	{
 		if(connectionString == null) throw new NullPointerException();	
 
@@ -56,7 +76,13 @@ public final class SimpleGdbFactory
 		{
 			try 
 			{
-				con = DriverManager.getConnection(connectionString);
+                if (userName == null){
+                    con = DriverManager.getConnection(connectionString);
+                } else if (passWord == null){
+                    con = DriverManager.getConnection(connectionString, userName, "");
+                } else {
+                    con = DriverManager.getConnection(connectionString, userName, passWord);
+                }
 				stmt = con.createStatement();
 			} 
 			catch (SQLException e) 
@@ -83,9 +109,9 @@ public final class SimpleGdbFactory
 		switch (version)
 		{
 		case 2:
-			return new SimpleGdbImpl2(dbName, connectionString);
+			return new SimpleGdbImpl2(dbName, connectionString, userName, passWord);
 		case 3:
-			return new SimpleGdbImpl3(dbName, connectionString);
+			return new SimpleGdbImpl3(dbName, connectionString, userName, passWord);
 		//NB add future schema versions here
 		default:
 			throw new IDMapperException ("Unrecognized schema version '" + version + "', please make sure you have the latest " +

--- a/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbImpl2.java
+++ b/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbImpl2.java
@@ -77,9 +77,10 @@ class SimpleGdbImpl2 extends SimpleGdbImplCommon
 	 * 	or PROP_NONE if you want to connect read-only
 	 * @throws IDMapperException when the database could not be created or connected to
 	 */
-	public SimpleGdbImpl2(String dbName, String connectionString) throws IDMapperException
+	public SimpleGdbImpl2(String dbName, String connectionString, String userName, String passWord) 
+            throws IDMapperException
 	{
-		super (dbName, connectionString);
+		super (dbName, connectionString, userName, passWord);
 		
 		if(dbName == null) throw new NullPointerException();		
 		checkSchemaVersion();

--- a/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbImpl3.java
+++ b/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbImpl3.java
@@ -41,9 +41,10 @@ class SimpleGdbImpl3 extends SimpleGdbImplCommon
 	 * 	or PROP_NONE if you want to connect read-only
 	 * @throws IDMapperException when the database could not be created or connected to
 	 */
-	public SimpleGdbImpl3(String dbName, String connectionString) throws IDMapperException
+	public SimpleGdbImpl3(String dbName, String connectionString, String userName, String passWord) 
+            throws IDMapperException
 	{
-		super(dbName, connectionString);
+		super(dbName, connectionString, userName, passWord);
 		checkSchemaVersion();
 	}
 	

--- a/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbImplCommon.java
+++ b/org.bridgedb.rdb/src/org/bridgedb/rdb/SimpleGdbImplCommon.java
@@ -23,9 +23,10 @@ import org.bridgedb.impl.InternalUtils;
  */
 public abstract class SimpleGdbImplCommon extends SimpleGdb
 {
-	SimpleGdbImplCommon(String dbName, String connectionString) throws IDMapperException
+	SimpleGdbImplCommon(String dbName, String connectionString, String userName, String passWord) 
+            throws IDMapperException
 	{
-		super(dbName, connectionString);
+		super(dbName, connectionString, userName, passWord);
 		caps = new SimpleGdbCapabilities();
 	}
 


### PR DESCRIPTION
Added the ability to handle userName and password to the connection without making then required.
This was desirable for security on our mySQL server.

The public methods exist in both the previous version and the new with userName and password version.
Non public method only have the new signature.

All getConnection methods check if userName is null. 
If so the methond without UserName is used.
If and only if userName and passWord are provided will they be used.
