### PR TITLE
8 casnumber regexp fix

### DIFF
--- a/org.bridgedb.bio/src/org/bridgedb/bio/BioDataSource.java
+++ b/org.bridgedb.bio/src/org/bridgedb/bio/BioDataSource.java
@@ -459,7 +459,7 @@ public class BioDataSource
 
 		DataSourcePatterns.registerPattern(
 				BioDataSource.CAS,
-				Pattern.compile("\\d+-\\d+-\\d+")
+				Pattern.compile("\\d+-\\d{2}-\\d{1}")
 		);
 		
 		DataSourcePatterns.registerPattern(

--- a/org.bridgedb.bio/test/org/bridgedb/bio/Test.java
+++ b/org.bridgedb.bio/test/org/bridgedb/bio/Test.java
@@ -82,6 +82,15 @@ public class Test
 	}
 
 	@org.junit.Test
+	public void testBasCASNumbers()
+	{
+		assertFalse(DataSourcePatterns.getDataSourceMatches("50-99-77").contains(BioDataSource.CAS));
+		assertFalse(DataSourcePatterns.getDataSourceMatches("1-99-77").contains(BioDataSource.CAS));
+		assertFalse(DataSourcePatterns.getDataSourceMatches("50-1-7").contains(BioDataSource.CAS));
+		assertFalse(DataSourcePatterns.getDataSourceMatches("50-333-7").contains(BioDataSource.CAS));
+	}
+
+	@org.junit.Test
 	public void testDataSource()
 	{
 		DataSource ds = BioDataSource.ENSEMBL;


### PR DESCRIPTION
A fix for the regular expression for CAS registry numbers, which only allow one digit in the last position, and expects exactly two digits between the hyphens.
